### PR TITLE
Updates to support Capybara 2.5.0 -> 2.6.2

### DIFF
--- a/dmc_kanye.gemspec
+++ b/dmc_kanye.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capybara", "=2.4.4"
+  spec.add_dependency "capybara", [">= 2.5.0", "~>2.6.2"]
   spec.add_dependency "poltergeist", "=1.5.1"
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/dmc_kanye/duck_punching_insurance.rb
+++ b/lib/dmc_kanye/duck_punching_insurance.rb
@@ -2,12 +2,6 @@ require 'capybara'
 require 'capybara/poltergeist'
 require 'capybara/poltergeist/version'
 
-unless Capybara::VERSION == "2.4.4"
-  raise "Kanye specifically monkey-patched version 2.4.4 of Capybara. "\
-        "You have version #{Capybara::VERSION}. "\
-        "Please upgrade the monkey patches along with the gem."
-end
-
 unless Capybara::Poltergeist::VERSION == "1.5.1"
   raise "Kanye specifically monkey-patched version 1.5.1 of Poltergeist. "\
         "You have version #{Capybara::Poltergeist::VERSION}. "\

--- a/lib/dmc_kanye/imma_let_you_finish.rb
+++ b/lib/dmc_kanye/imma_let_you_finish.rb
@@ -49,7 +49,7 @@ module Capybara
     class Base
 ##### START PUNCHING DUCKS
 # orig code:
-#       def synchronize(seconds=Capybara.default_wait_time, options = {})
+#       def synchronize(seconds=Capybara.default_max_wait_time, options = {})
 # new code:
       def synchronize(seconds = nil, options = {})
         kanye_in_the_house = session.driver.respond_to?(:kanye_invited?) && session.driver.kanye_invited?
@@ -58,10 +58,10 @@ module Capybara
         elsif kanye_in_the_house
           seconds_to_wait = DmcKanye::Config.default_wait_time || Capybara.default_wait_time
         else
-          seconds_to_wait = Capybara.default_wait_time
+          seconds_to_wait = Capybara.default_max_wait_time
         end
 ##### STOP PUNCHING DUCKS, BACK TO ORIGINAL CODE
-        start_time = Time.now
+        start_time = Capybara::Helpers.monotonic_time
 
         if session.synchronized
           yield
@@ -83,12 +83,12 @@ module Capybara
             raise e unless catch_error?(e, options[:errors])
 ##### START PUNCHING DUCKS
 # orig code:
-#            raise e if (Time.now - start_time) >= seconds
+#            raise e if (Capybara::Helpers.monotonic_time - start_time) >= seconds
 # new code:
-            raise e if (Time.now - start_time) >= seconds_to_wait
+            raise e if (Capybara::Helpers.monotonic_time - start_time) >= seconds_to_wait
 ##### STOP PUNCHING DUCKS, BACK TO ORIGINAL CODE
             sleep(0.05)
-            raise Capybara::FrozenInTime, "time appears to be frozen, Capybara does not work with libraries which freeze time, consider using time travelling instead" if Time.now == start_time
+            raise Capybara::FrozenInTime, "time appears to be frozen, Capybara does not work with libraries which freeze time, consider using time travelling instead" if Capybara::Helpers.monotonic_time == start_time
             reload if Capybara.automatic_reload
             retry
           ensure

--- a/lib/dmc_kanye/version.rb
+++ b/lib/dmc_kanye/version.rb
@@ -1,3 +1,3 @@
 module DmcKanye
-  VERSION = "0.0.1"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
This addresses #2 (at least in that it allows Capybara versions *newer* than 2.4.4). It comes with a version bump to Kanye, because it actually *requires* Capybara to be 2.5.0 or newer, and thus will trigger several gem updates.

I've constrained the dependency to max out at 2.6.2, which is the highest tag in Capybara at this time, in case a newer version breaks Kanye.