### PR TITLE
Supports Capybara 2.4.x

### DIFF
--- a/dmc_kanye.gemspec
+++ b/dmc_kanye.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capybara", "=2.4.4"
+  spec.add_dependency "capybara", "~> 2.4.4"
   spec.add_dependency "poltergeist", "=1.5.1"
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/dmc_kanye/duck_punching_insurance.rb
+++ b/lib/dmc_kanye/duck_punching_insurance.rb
@@ -2,12 +2,6 @@ require 'capybara'
 require 'capybara/poltergeist'
 require 'capybara/poltergeist/version'
 
-unless Capybara::VERSION == "2.4.4"
-  raise "Kanye specifically monkey-patched version 2.4.4 of Capybara. "\
-        "You have version #{Capybara::VERSION}. "\
-        "Please upgrade the monkey patches along with the gem."
-end
-
 unless Capybara::Poltergeist::VERSION == "1.5.1"
   raise "Kanye specifically monkey-patched version 1.5.1 of Poltergeist. "\
         "You have version #{Capybara::Poltergeist::VERSION}. "\

--- a/lib/dmc_kanye/version.rb
+++ b/lib/dmc_kanye/version.rb
@@ -1,3 +1,3 @@
 module DmcKanye
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Loosens the pin for this version of Kanye to support all Capybara's 2.4.x series (2.4.0-2.4.4) instead of just 2.4.4. The duck-punching should work with any of those versions, since the class being patched doesn't change in that series.

I've ticked the patch-level for Kanye to 0.0.2 here - it shouldn't affect people already using Kanye with Capybara 2.4.4, but it is a change from 0.0.1.