### PR TITLE
Remove Poltergeist version pin

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,3 @@
 # DMC-Kanye TODO
 
 * [ ] Tests! (How meta...)
-* [ ] Check duck-punching against different versions of Poltergeist to allow less-restrictive version pinning
-* [ ] Check duck-punching against different versions of Capybara to allow less-restrictive version pinning

--- a/dmc_kanye.gemspec
+++ b/dmc_kanye.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capybara", [">= 2.5.0", "~>2.6.2"]
-  spec.add_dependency "poltergeist", "=1.5.1"
+  spec.add_dependency "poltergeist", "~> 1.5"
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/lib/dmc_kanye/duck_punching_insurance.rb
+++ b/lib/dmc_kanye/duck_punching_insurance.rb
@@ -1,9 +1,0 @@
-require 'capybara'
-require 'capybara/poltergeist'
-require 'capybara/poltergeist/version'
-
-unless Capybara::Poltergeist::VERSION == "1.5.1"
-  raise "Kanye specifically monkey-patched version 1.5.1 of Poltergeist. "\
-        "You have version #{Capybara::Poltergeist::VERSION}. "\
-        "Please upgrade the monkey patches along with the gem."
-end


### PR DESCRIPTION
I don't see any particular reason why this needs to be version-pinned. We add methods to a Poltergeist class but don't tromp all over it. Calls out to other classes in the Poltergeist API are minimal. This removes the pins and checks; if we run into a version incompatibility down the line, we can tighten it back up.

Closes #3 .